### PR TITLE
Ability for settings file to add image processing modes.

### DIFF
--- a/openross/image_modes.py
+++ b/openross/image_modes.py
@@ -1,4 +1,5 @@
 import pgmagick as pg
+import settings
 
 """ This Module is where image processing functions are defined.
     It will contain a mapping between mode and processing functions
@@ -103,3 +104,7 @@ _register_mode('resize', _resize)
 _register_mode('resizecomp', _resizecomp)
 _register_mode('crop', _crop)
 _register_mode('trimresize', _trim_resize)
+
+if hasattr(settings, 'CUSTOM_IMAGE_MODES'):
+    for mode_name, mode_handler in settings.CUSTOM_IMAGE_MODES.items():
+        _register_mode(mode_name, mode_handler)

--- a/openross/image_modes.py
+++ b/openross/image_modes.py
@@ -105,6 +105,5 @@ _register_mode('resizecomp', _resizecomp)
 _register_mode('crop', _crop)
 _register_mode('trimresize', _trim_resize)
 
-if hasattr(settings, 'CUSTOM_IMAGE_MODES'):
-    for mode_name, mode_handler in settings.CUSTOM_IMAGE_MODES.items():
-        _register_mode(mode_name, mode_handler)
+for mode_name, mode_handler in settings.CUSTOM_IMAGE_MODES.items():
+    _register_mode(mode_name, mode_handler)

--- a/openross/pipeline/resizer.py
+++ b/openross/pipeline/resizer.py
@@ -26,7 +26,8 @@ class Resizer(object):
 
         # Image should be repaged after a crop/resize
         img.page(pg.Geometry(0, 0, 0, 0))
-        img.quality(90)  # minimise artifacts but keep size down
+        if settings.IMAGE_QUALITY is not None:  # May be handled by custom mode
+            img.quality(settings.IMAGE_QUALITY)
 
         img.write(blob_out, 'JPEG')
         return blob_out.data, img.size().width(), img.size().height()

--- a/openross/pipeline/s3_downloader.py
+++ b/openross/pipeline/s3_downloader.py
@@ -19,11 +19,12 @@ class S3Downloader(object):
             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
         )
-        self.txs3conn = AWSServiceRegion(
-            access_key=settings.AWS_ACCESS_KEY_ID,
-            secret_key=settings.AWS_SECRET_ACCESS_KEY,
-            s3_uri=S3_EU_WEST[0]['endpoint'],
-        ).get_s3_client()
+        if not settings.USE_BOTO:
+            self.txs3conn = AWSServiceRegion(
+                access_key=settings.AWS_ACCESS_KEY_ID,
+                secret_key=settings.AWS_SECRET_ACCESS_KEY,
+                s3_uri=S3_EU_WEST[0]['endpoint'],
+            ).get_s3_client()
         self.botobucket = self.s3conn.get_bucket(settings.IMAGES_STORE)
 
     @defer.inlineCallbacks

--- a/openross/settings.py
+++ b/openross/settings.py
@@ -38,6 +38,7 @@ IMAGE_WHITELIST_SETTING = [
     ('200', '250'),
     ('1024', '768'),
 ]
+IMAGE_QUALITY = 90  # minimise artifacts but keep size down
 
 # Turn the above human readable white list into an efficient lookup table
 IMAGE_WHITELIST = {}

--- a/openross/settings.py
+++ b/openross/settings.py
@@ -49,6 +49,7 @@ for size in IMAGE_WHITELIST_SETTING:
 for key in IMAGE_WHITELIST.keys():
     IMAGE_WHITELIST[key] = set(IMAGE_WHITELIST[key])
 
+CUSTOM_IMAGE_MODES = {}
 ALLOWED_MODES = [
     'resize',
     'resizecomp',


### PR DESCRIPTION
I wanted to add custom image processing modes, but this isn't straightforward without manually editing image_modes.py. This patch allows the .openross.py settings file to add custom modes by defining a dict called CUSTOM_IMAGE_MODES.